### PR TITLE
Use https for Google geocoding

### DIFF
--- a/Azavea.Open.Geocoding.Google/GoogleGeocoder.cs
+++ b/Azavea.Open.Geocoding.Google/GoogleGeocoder.cs
@@ -59,7 +59,7 @@ namespace Azavea.Open.Geocoding.Google
         /// <returns>A <code>GeocodeResponse</code> describing the results of the geocode.</returns>
         protected override GeocodeResponse InternalGeocode(GeocodeRequest geocodeRequest)
         {
-            const string baseGoogleGeocodeUrl = @"http://maps.googleapis.com/maps/api/geocode/xml";
+            const string baseGoogleGeocodeUrl = @"https://maps.googleapis.com/maps/api/geocode/xml";
 
             // For the address, either use the address field or the text string, 
             // depending on which one has a value.  Then, add each following address

--- a/Azavea.Open.Geocoding.Google/Tests/GoogleTests.cs
+++ b/Azavea.Open.Geocoding.Google/Tests/GoogleTests.cs
@@ -48,11 +48,9 @@ namespace Azavea.Open.Geocoding.Google.Tests
 
             GeocodeResponse gRes = _googleGeocoder.Geocode(gr);
             TestUtils.OutputGeocodeResponses(gRes);
-            Assert.IsTrue(gRes.Candidates.Count == 3, "Expected the geocoder to return 3 results");
+            Assert.IsTrue(gRes.Candidates.Count == 1, "Expected the geocoder to return 3 results");
 
-            Assert.AreEqual("street_address", gRes.Candidates[1].MatchType, "Expected the second match to have the type 'street_address'");
             Assert.AreEqual("premise", gRes.Candidates[0].MatchType, "Expected the first match to have the type 'premise'");
-            Assert.AreEqual("point_of_interest", gRes.Candidates[2].MatchType, "Expected the third match to have the type 'point_of_interest'");
         }
 
         ///<exclude/>
@@ -132,7 +130,7 @@ namespace Azavea.Open.Geocoding.Google.Tests
             TestUtils.OutputGeocodeResponses(gRes);
 
             Assert.AreEqual(1, gRes.Candidates.Count);
-            Assert.AreEqual("Tasker Street & South 15th Street, Philadelphia, PA 19146, USA", gRes.Candidates[0].StandardizedAddress, "Geocoder found wrong intersection");
+            Assert.AreEqual("Tasker St & S 15th St, Philadelphia, PA 19146, USA", gRes.Candidates[0].StandardizedAddress, "Geocoder found wrong intersection");
         }
         
         ///<exclude/>
@@ -145,7 +143,7 @@ namespace Azavea.Open.Geocoding.Google.Tests
             TestUtils.OutputGeocodeResponses(gRes);
 
             Assert.AreEqual(1, gRes.Candidates.Count);
-            Assert.AreEqual("North 21st Street & Cherry Street, Philadelphia, PA 19103, USA", gRes.Candidates[0].StandardizedAddress, "Geocoder found wrong intersection");
+            Assert.AreEqual("N 21st St & Cherry St, Philadelphia, PA 19103, USA", gRes.Candidates[0].StandardizedAddress, "Geocoder found wrong intersection");
         }
 
         ///<exclude/>
@@ -175,7 +173,7 @@ namespace Azavea.Open.Geocoding.Google.Tests
             TestUtils.OutputGeocodeResponses(gRes);
             Assert.AreEqual(1, gRes.Candidates.Count, "Expected the geocoder to return 1 result");
             Assert.AreEqual("intersection", gRes.Candidates[0].MatchType, "Expected the match type to be 'intersections'");
-            Assert.AreEqual("North 12th Street & Callowhill Street, Philadelphia, PA 19123, USA", gRes.Candidates[0].StandardizedAddress);
+            Assert.AreEqual("N 12th St & Callowhill St, Philadelphia, PA 19123, USA", gRes.Candidates[0].StandardizedAddress);
         }
     }
 }


### PR DESCRIPTION
## Overview

Google will soon start requiring a key and when making API requests and API requests with a key must be made over https.

I also fixed the unit tests in the `Azavea.Open.Geocoding.Google` library. All but one of the failures were the result of Google now returning abbreviations like "St" rather than "Street" The remaining failure was caused by and expectation that the geocoder returned three results of different types rather than a single "premise" result.

Connects https://github.com/azavea/phillyhistory/issues/63

### Notes

The `GeocoderUS` tests fail because the gecoder.us domain no longer exists. That library should be removed from the solution, but it is out of the scope of this PR.

## Testing Instructions

 * Look up the `Azavea Common Unit Testing Google Geocoder API Key` in the shared credential store and add it to `Azavea.Open.Geocoding\Azavea.Open.Geocoding.Google\Tests\GoogleTests.config`
 * Build the library and run the unit tests for the `Azavea.Open.Geocoding.Google` library. Confirm that they pass.
